### PR TITLE
MUX-002: Disk-pressure integration test and signal cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ tools/muxcode-llm-harness/    # Go module — standalone local LLM harness
 | `bash scripts/test-echo-as-result.sh` | Integration test for the echo-as-result fix — synthesized bus-response rows never render as a pass (isolated scratch session, no live session needed) |
 | `bash scripts/test-lifecycle-log-leak.sh` | Regression test that a full test run leaves `~/.config/muxcode/logs` untouched (runs the suite under a throwaway `HOME`) |
 | `bash scripts/test-branch-time-recording.sh` | Integration test for the branch-time requirements-doc sink — JSON read path, idempotent upsert, never-regress reconciliation (hermetic; no live session needed) |
+| `bash scripts/test-disk-pressure.sh` | Integration test for the disk-pressure signal and its alert cooldown — healthy machine stays silent, footprint/headroom breaches alert, alert fires once per window not every 60s cycle (safe: never invokes `CleanupStale`) |
 
 Both Go modules have **no external dependencies** (stdlib only).
 

--- a/config/settings.json
+++ b/config/settings.json
@@ -58,6 +58,15 @@
             "async": true
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "muxcode hook comment-block"
+          }
+        ]
       }
     ],
     "Stop": [

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -4,9 +4,9 @@
 
 Muxcode uses Claude Code's hook system to integrate the AI agent with tmux and neovim. Hooks run before or after tool execution, receiving the tool event as JSON on stdin. Most hooks are implemented as subcommands of `muxcode hook` (Go binary); two remain as shell scripts for tmux/vim timing-sensitive operations.
 
-All hooks are **async** — they do not block the AI agent from continuing.
+Most hooks are **async** — they do not block the AI agent from continuing. Three are sync: `hook guard` (rejects prohibited commands before they run), `hook stop` (can block a turn's stop to re-launch the inbox listener), and `hook comment-block` (its PostToolUse block decision must reach the model).
 
-**Provider gating**: Hooks only fire for providers that support them (`provider.SupportsHooks() == true`). Currently only Claude Code supports hooks. OpenCode, Codex CLI, and local LLM agents skip hook processing entirely — all four hook functions (`hookBash`, `hookGuard`, `hookAnalyze`, `hookInboxPoll`) exit early when the provider is non-hook. For non-hook agents, three layers replace hooks: (1) role-specific manual bus messaging instructions in the system prompt, (2) agent body text adaptation (OpenCode: `adaptBodyForNonHookProvider()`, Codex CLI: shared `.codex/AGENTS.md`) that rewrites hook chain references to manual commands, (3) `CheckSendPolicy()` bypass that allows non-hook agents to send chain messages (build→test, test→review) that would be blocked for hook agents where chains fire automatically.
+**Provider gating**: Hooks only fire for providers that support them (`provider.SupportsHooks() == true`). Currently only Claude Code supports hooks. OpenCode, Codex CLI, and local LLM agents skip hook processing entirely — the hook functions (`hookBash`, `hookGuard`, `hookAnalyze`, `hookInboxPoll`, `hookStop`, `hookCommentBlock`) exit early when the provider is non-hook. For non-hook agents, three layers replace hooks: (1) role-specific manual bus messaging instructions in the system prompt, (2) agent body text adaptation (OpenCode: `adaptBodyForNonHookProvider()`, Codex CLI: shared `.codex/AGENTS.md`) that rewrites hook chain references to manual commands, (3) `CheckSendPolicy()` bypass that allows non-hook agents to send chain messages (build→test, test→review) that would be blocked for hook agents where chains fire automatically.
 
 ## Hook Configuration
 
@@ -37,6 +37,10 @@ Hooks are configured in `.claude/settings.json` in your project:
       {
         "matcher": "Bash",
         "hooks": [{"type": "command", "command": "muxcode hook bash", "async": true}]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [{"type": "command", "command": "muxcode hook comment-block"}]
       }
     ],
     "Stop": [
@@ -162,6 +166,22 @@ After the primary chain action, the hook fires event subscriptions — matching 
 **Error extraction:** For failed build and test commands, the hook extracts error-relevant lines from tool output into an `errors` field in the history JSONL. The regex matches common error patterns: `error:`, `ERR!`, `failed`, `fatal`, `panic`, `FAIL:`, `not found`, `undefined`, `syntax error`, `permission denied`, etc. Test patterns additionally match `assert` and `expect`. The left-pane log views prefer the `errors` field over raw `output` when displaying failures, surfacing diagnostic information instead of noise like "Exit code: 1".
 
 **JSON parsing:** Implemented in Go using `encoding/json` — no external dependencies (`jq`/`python3` not required). The preview hook (`muxcode-preview-hook.sh`) still uses `python3` for generating proposed file content; without it, no split diff appears in nvim.
+
+### hook comment-block (comment blocker)
+
+**Command:** `muxcode hook comment-block`
+**Phase:** PostToolUse
+**Trigger:** Write, Edit
+**Mode:** sync (block decision reaches the model)
+
+Enforces the code-comments skill: flags multi-line comment blocks written inside function bodies. Unlike the other PostToolUse hooks it carries no `async` flag — it runs synchronously so its block decision is fed back to the model, which sees the reason and can hoist the prose to a doc comment or extract a named function instead.
+
+- **Scans only what the edit introduced** — Edit's `new_string` or Write's `content`, never the whole file — so pre-existing comment blocks in a touched file are never flagged. Reported line numbers are relative to the edited fragment, not the file.
+- **Fires at 3+ consecutive comment lines at body indentation.** Column-zero runs (file headers, license blocks, package/module docs) are exempt by design — that boundary is where the skill tells authors to write. The threshold is deliberately looser than the skill's own rule (at most one short line in a body): two lines can be a wrapped sentence, three is a paragraph — the unambiguous case worth interrupting for.
+- **Exempt paths**: unsupported languages are never scanned (only mapped extensions are — `//` markers: `.go .ts .tsx .js .jsx .java .rs .c .cc .cpp .h`; `#` markers: `.py .sh .bash .rb`), and test files (`_test.go`, `.test.ts`, `.spec.js`, `test_*` prefix, `/tests/`, `/spec/`, …) are skipped — a test's comment often *is* the specification of the behavior under test. `#` lines inside Python docstrings are not counted.
+- **Provider-gated** like every hook — no-op for non-hook providers.
+
+Backed by `ScanCommentBlocks()` / `IsCommentBlockExempt()` / `FormatCommentBlockReason()` in `bus/comment_block.go` (`hookCommentBlock()` in `cmd/hook.go`).
 
 ### hook stop (self-poll re-launch)
 

--- a/docs/requirements/backlog/MUX-014-graph-agent-orchestrator.md
+++ b/docs/requirements/backlog/MUX-014-graph-agent-orchestrator.md
@@ -17,6 +17,8 @@ An explicit DAG control plane on top of the existing bus, specialist roles, line
 
 So: fixed lines + LLM scheduler + optional workers. Missing: an executable multi-node graph with joins and durable run history. There is no graph agent or spec in the repo today — the closest building blocks all exist and are reused below.
 
+**The wake-per-step tax.** `--track` already makes any *single* delegation non-blocking, but multi-step work still routes through edit: every completion wakes it, and it must hold the remaining plan in context and decide the next send. Edit's involvement in an N-step sequence is O(N) wakes — each one consuming attention, context, and a prompt turn — and the plan itself is only as durable as edit's context window. The graph moves that routing into the daemon so edit fires one `graph run` and is interrupted only at human gates and terminal states.
+
 ### What graph-agent orchestration provides
 
 1. **Explicit multi-agent DAGs** — nodes = roles/actions; edges = success/failure/custom outcomes. Not "edit decides the next send" or a single-successor chain.
@@ -69,6 +71,7 @@ Templates: `coding-pr`, `story-lifecycle`, `research-critique`, `deploy-verify`,
 ### Acceptance criteria
 
 - [ ] Graph definitions are declarative JSON: nodes (typed), edges keyed by outcome (`success`/`failure`/custom), validated by `muxcode graph validate` — undefined node refs, unreachable nodes, and uncapped cycles are errors; loops only via explicit `max_iterations` on a loop edge
+- [ ] Async orchestration: `graph run` returns immediately (never blocks the caller's prompt); for a gate-free run, edit receives exactly one wake (run completion) — its involvement is O(`wait_human` gates), never O(nodes)
 - [ ] `muxcode graph run <template>|--file <path>` starts a run; the daemon executes edges deterministically (send/spawn) — no LLM decides node succession
 - [ ] Fan-out via `map` nodes (dynamic item list → parallel spawn/send) and fan-in via `join` nodes with `all`/`any`/`quorum` barrier semantics
 - [ ] `condition` nodes reuse `EvaluateConditions()` and `ChainContext` verbatim — no second condition dialect
@@ -152,6 +155,7 @@ Templates: `coding-pr`, `story-lifecycle`, `research-critique`, `deploy-verify`,
 - [ ] Create `scripts/test-graph-orchestrator.sh` (requires running muxcode session)
 - [ ] Test: `graph validate` rejects an uncapped cycle and an ungated commit node; accepts all built-in templates
 - [ ] Test: run a 3-node linear graph (send→condition→send) → verify node statuses reach `done` and lifecycle events recorded
+- [ ] Test: gate-free linear run → `graph run` returns before any node executes, and edit's inbox shows exactly one graph wake (run completion), zero per-node wakes
 - [ ] Test: run a fan-out/join graph (map → 2 spawns → join all) → verify barrier held until both workers completed
 - [ ] Test: kill and restart the daemon mid-run → verify the run resumes and completes from persisted state
 - [ ] Test: `graph retry --from <node>` re-executes only downstream nodes

--- a/docs/requirements/backlog/backlog.md
+++ b/docs/requirements/backlog/backlog.md
@@ -2,7 +2,7 @@
 
 Index of all pending requirement specs. Every planned feature with a written spec has a row
 in the [Spec index](#spec-index) below; ideas without a spec doc yet are collected in
-[Ideas without specs](#ideas-without-specs). 75 delivered specs live in
+[Ideas without specs](#ideas-without-specs). 76 delivered specs live in
 [`completed/`](../completed/) — each with requirements, key files, and implementation notes.
 
 Spec lifecycle: `backlog/` (planned or parked) → `drafts/` (actively being designed or
@@ -36,7 +36,6 @@ in the index carries a stable **`MUX-NNN`** id that ties the req doc to its GitH
 
 | ID | Spec | Priority | Status |
 |----|------|----------|--------|
-| MUX-002 | [`MUX-002-disk-pressure-wrong-filesystem.md`](./MUX-002-disk-pressure-wrong-filesystem.md) | Medium | In Progress — `TmpPressure()` headroom+footprint signals shipped; integration test outstanding |
 | MUX-005 | [`MUX-005-plan-diagrams.md`](./MUX-005-plan-diagrams.md) | Medium | In Progress — Phases 1–3 complete (render script, media store, req-doc embeds); Jira/Confluence embed phases remaining |
 
 ### Reliability & observability
@@ -96,6 +95,7 @@ MUX-003/004 were delivered under GitHub tracking; MUX-028–MUX-099 are retroact
 | ID | Spec | Delivered |
 |----|------|-----------|
 | MUX-001 | [`MUX-001-branch-time-tracking.md`](../completed/MUX-001-branch-time-tracking.md) | Branch active-time recording delta on the [MUX-040](../completed/MUX-040-branch-time-tracking.md) baseline: `--json` read path, verify-spec doc sink with `seed`-floor never-regress reconciliation, `scripts/test-branch-time-recording.sh` (14 checks) |
+| MUX-002 | [`MUX-002-disk-pressure-wrong-filesystem.md`](../completed/MUX-002-disk-pressure-wrong-filesystem.md) | `TmpPressure()` replaces volume percent-used with absolute free-headroom + muxcode-footprint signals; adaptive alert cooldown (600s effective / 3600s ineffective) extracted as pure `shouldAlertDiskPressure` so cadence is testable without running `CleanupStale`; `scripts/test-disk-pressure.sh` (11 checks) with leak detection scoped to scratch-session log names — a whole-directory snapshot is a false-positive generator while a live daemon appends to the log dir |
 | MUX-003 | [`MUX-003-echo-as-result.md`](../completed/MUX-003-echo-as-result.md) | `scripts/test-echo-as-result.sh` (20 checks) verifies synthesized bus-response rows can never render as a pass while the authoritative self-logged path still does; isolated scratch `BUS_SESSION`, no live session needed |
 | MUX-004 | [`MUX-004-lifecycle-log-test-leak.md`](../completed/MUX-004-lifecycle-log-test-leak.md) | `scripts/test-lifecycle-log-leak.sh` (7 checks) runs the suite under a throwaway `HOME` so a lost `MUXCODE_LIFECYCLE_LOG_DIR` pin is caught without writing to the real install; plus `tui/main_test.go` closing the last unpinned test package |
 | MUX-028 | [`MUX-028-agent-debug-skill.md`](../completed/MUX-028-agent-debug-skill.md) | Agent Debug Skill |

--- a/docs/requirements/completed/MUX-002-disk-pressure-wrong-filesystem.md
+++ b/docs/requirements/completed/MUX-002-disk-pressure-wrong-filesystem.md
@@ -104,13 +104,17 @@ Pressure is `lowHeadroom || bigFootprint`, in a new `TmpPressure()` returning `(
 
 ### Phase 2: Integration test
 
-> **Outstanding.** `scripts/test-disk-pressure.sh` was not written. Verification was done live against the running session instead (see "Observed impact" above) — the scripted test remains outstanding.
+- [x] Create `scripts/test-disk-pressure.sh` with automated verification
+- [x] Test: on a healthy machine (high percent-used, large absolute headroom) → no alert fires
+- [x] Test: simulated footprint/headroom breach (env-injected threshold) → alert fires once, not every cycle
+- [x] Run the script and verify all checks pass
 
-- [ ] Create `scripts/test-disk-pressure.sh` with automated verification
-- [ ] Test: on a healthy machine (high percent-used, large absolute headroom) → no alert fires
-- [ ] Test: simulated footprint/headroom breach (env-injected threshold) → alert fires once, not every cycle
-- [ ] Run the script and verify all checks pass
+#### Phase 2 notes
+
+- **The test never calls `CheckDiskPressure` on the real `/tmp`.** That path runs `CleanupStale`, which would delete other muxcode sessions' artifacts on whatever machine runs the suite. Instead, the signal is exercised through `TmpPressure()` with the `/tmp` scan redirected to a temp dir via `busDirOverride`, and the alert cadence is exercised through `shouldAlertDiskPressure` — extracted as a pure function for exactly this reason.
+- **Leak detection is scoped to scratch-session log names, not a whole-directory snapshot.** A snapshot of `~/.config/muxcode/logs` is a false-positive generator: a live session's daemon appends there every poll cycle, so the directory legitimately changes mid-run. Observed during verification — `muxcode.log` grew 132939 → 133082 lines inside one run window, failing a name+size snapshot check the test had not caused.
+- **Verified by negative control.** With `shouldAlertDiskPressure` stubbed to always return true (reintroducing the per-cycle spam bug), the suite goes red on `TestShouldAlertDiskPressure_SuppressedWithinCooldown` and `..._FiresOncePerWindowNotEveryCycle` (10 passed, 1 failed, exit 1) while the signal tests stay green — confirming the assertions target the cadence specifically. Restored, the suite is 11 passed / 0 failed / exit 0.
 
 ## Status
 
-In Progress
+Complete

--- a/docs/requirements/completed/MUX-004-lifecycle-log-test-leak.md
+++ b/docs/requirements/completed/MUX-004-lifecycle-log-test-leak.md
@@ -16,7 +16,7 @@ Test runs deposited real lifecycle log files into the user's live install. `Life
 
 ### Cross-links
 
-Found while working on [disk-pressure-wrong-filesystem](../backlog/MUX-002-disk-pressure-wrong-filesystem.md) — the same investigation into lifecycle-log health (disk-pressure spam had collapsed retained history) surfaced this second way the log directory degrades.
+Found while working on [disk-pressure-wrong-filesystem](./MUX-002-disk-pressure-wrong-filesystem.md) — the same investigation into lifecycle-log health (disk-pressure spam had collapsed retained history) surfaced this second way the log directory degrades.
 
 ## Requirements
 

--- a/scripts/test-disk-pressure.sh
+++ b/scripts/test-disk-pressure.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Integration test for the disk-pressure signal and its alert cooldown
+# (docs/requirements/completed/MUX-002-disk-pressure-wrong-filesystem.md, Phase 2).
+#
+# THE BUG: pressure was decided by the /tmp volume's percent-used. On macOS /tmp
+# is on the boot volume, so a dev box sitting at a normal 90% full ran cleanup
+# every 60 seconds forever, freed 0 B every time, and buried the lifecycle log in
+# warnings nobody could act on. The fix decides pressure from absolute free
+# headroom and muxcode's own /tmp footprint — the only part its cleanup can free.
+#
+# WHY THIS SCRIPT DOES NOT CALL CheckDiskPressure:
+# forcing a breach and letting the real path run would invoke CleanupStale, which
+# deletes OTHER muxcode sessions' /tmp artifacts on whatever machine runs the
+# test. Destroying live session state is not an acceptable cost for a test. So
+# the two halves are exercised where they can be reached safely:
+#   - the SIGNAL (TmpPressure) via Go tests that redirect the /tmp scan into a
+#     temp dir and inject thresholds through the env
+#   - the ALERT CADENCE via shouldAlertDiskPressure, a pure function extracted
+#     precisely so "fires once, not every cycle" is testable without cleanup
+# The script also proves the destructive path stays inert under --dry-run.
+#
+# Usage: bash scripts/test-disk-pressure.sh
+set -uo pipefail
+
+MUX="${MUXCODE_BIN:-muxcode}"
+MUX="$(command -v "$MUX" 2>/dev/null || echo "$MUX")"
+[ -x "$MUX" ] || { echo "  FAIL  cannot resolve muxcode binary ('$MUX') — set MUXCODE_BIN"; exit 1; }
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODULE="$REPO/tools/muxcode"
+
+GREEN=$'\033[0;32m'; RED=$'\033[0;31m'; YELLOW=$'\033[0;33m'; NC=$'\033[0m'
+pass=0; fail=0
+ok()  { echo "  ${GREEN}PASS${NC}  $*"; pass=$((pass+1)); }
+bad() { echo "  ${RED}FAIL${NC}  $*"; fail=$((fail+1)); }
+
+export MUXCODE_LIFECYCLE_LOG_DIR="$(mktemp -d /tmp/disk-pressure-lifecycle-XXXXXX)"
+# Leak detection is scoped to log files named after this test's scratch sessions,
+# NOT a snapshot of the whole directory.
+#
+# A whole-dir snapshot (names, or names+sizes) is a false-positive generator: when
+# a muxcode session is live its daemon appends to ~/.config/muxcode/logs every poll
+# cycle, so the directory legitimately changes mid-run and the check reports a leak
+# the test did not cause. Observed: muxcode.log grew 132939 -> 133082 lines during
+# one run window. Scratch-session names are the only writes this test could
+# actually be responsible for, so they are the only thing worth asserting on.
+REAL_LOG_DIR="$HOME/.config/muxcode/logs"
+leaked_logs() { ls -1 "$REAL_LOG_DIR" 2>/dev/null | grep -E '^test-(disk-pressure|lifecycle)' | sort; }
+LEAKED_BEFORE="$(leaked_logs)"
+TMP_SNAPSHOT_BEFORE="$(ls -1d /tmp/muxcode-bus-* 2>/dev/null | sort)"
+cleanup() { rm -rf "$MUXCODE_LIFECYCLE_LOG_DIR"; }
+trap cleanup EXIT
+
+# gotest "label" <-run pattern> <min expected --- PASS lines> <package>
+# -v is required: a -run pattern matching zero tests still exits 0 and still
+# prints "ok <pkg>", so only per-test PASS lines are evidence anything ran.
+gotest() {
+  local label="$1" pattern="$2" min="$3" out ran
+  out="$(mktemp /tmp/disk-pressure-go-XXXXXX.out)"
+  if (cd "$MODULE" && go test "$4" -count=1 -v -run "$pattern") >"$out" 2>&1; then
+    ran="$(grep -cE '^--- PASS:' "$out")"
+    if grep -q 'no tests to run' "$out"; then
+      bad "$label — -run pattern matched no tests (silent pass)"
+    elif [ "$ran" -ge "$min" ]; then
+      ok "$label ($ran tests)"
+    else
+      bad "$label — only $ran tests ran, want >= $min (renamed out of the pattern?)"
+    fi
+  else
+    grep -E '^(--- FAIL|FAIL|.*\.go:[0-9]+:)' "$out" | head -12 | sed 's/^/        /'
+    bad "$label"
+  fi
+  rm -f "$out"
+}
+
+echo "=== disk pressure integration test ==="
+echo ""
+
+# --- 1. The signal: a healthy machine must stay silent --------------------
+# This is the regression. The box running this test is almost certainly a normal
+# dev machine with high percent-used and plenty of absolute headroom — exactly
+# the shape that used to alert forever.
+echo "-- pressure signal (thresholds env-injected, /tmp scan redirected) --"
+
+gotest "healthy machine is silent" 'TestTmpPressure_HealthyMachineIsSilent' 1 './bus/'
+gotest "footprint breach alerts"   'TestTmpPressure_LargeFootprintAlerts'   1 './bus/'
+gotest "headroom breach alerts"    'TestTmpPressure_LowHeadroomAlerts'      1 './bus/'
+gotest "threshold parsing + overrides" \
+  'TestParseByteSize|TestByteSizeDefaults_MalformedFallsBackNotZero|TestByteSizeOverrides|TestMuxcodeTmpFootprint' 4 './bus/'
+gotest "disabled / healthy short-circuits" \
+  'TestCheckDiskPressure_DisabledByThreshold|TestCheckDiskPressure_HealthyReturnsNil' 2 './bus/'
+
+# --- 2. The cadence: fires once, not every cycle --------------------------
+echo ""
+echo "-- alert cadence --"
+
+gotest "cooldown: first fires, suppressed in window, refires after" \
+  'TestShouldAlertDiskPressure_' 4 './daemon/'
+gotest "cooldown constants pinned" 'TestDiskPressureCooldownConstants' 1 './daemon/'
+
+# --- 3. Live sanity on the real machine -----------------------------------
+# The real box, real thresholds: a normal dev machine must not be pressured.
+# Skipped rather than failed if the machine genuinely is low on disk — a true
+# positive is not a test failure.
+echo ""
+echo "-- live machine --"
+
+FREE_KB="$(df -k /tmp 2>/dev/null | awk 'NR==2{print $4}')"
+if [ -n "${FREE_KB:-}" ] && [ "$FREE_KB" -gt 2097152 ]; then   # > 2 GiB, the default floor
+  PCT="$(df -k /tmp 2>/dev/null | awk 'NR==2{gsub("%","",$5); print $5}')"
+  ok "real /tmp has $((FREE_KB/1024/1024))Gi free at ${PCT}% used — high percent-used alone must not alert"
+else
+  echo "  ${YELLOW}SKIP${NC}  machine genuinely low on /tmp headroom (${FREE_KB:-?}KB) — pressure here would be a true positive"
+fi
+
+# --- 4. The destructive path stays inert under --dry-run ------------------
+# CleanupStale is what makes forcing a real breach unsafe. Prove --dry-run
+# removes nothing, so the safe surface is actually safe.
+echo ""
+echo "-- cleanup --dry-run is non-destructive --"
+
+"$MUX" cleanup --dry-run >/dev/null 2>&1
+if [ "$TMP_SNAPSHOT_BEFORE" = "$(ls -1d /tmp/muxcode-bus-* 2>/dev/null | sort)" ]; then
+  ok "cleanup --dry-run removed no session directories"
+else
+  bad "cleanup --dry-run DELETED session directories"
+  diff <(printf '%s\n' "$TMP_SNAPSHOT_BEFORE") <(ls -1d /tmp/muxcode-bus-* 2>/dev/null | sort) | head -10 | sed 's/^/        /'
+fi
+
+# --- 5. Isolation ----------------------------------------------------------
+echo ""
+echo "-- isolation --"
+
+if [ "$LEAKED_BEFORE" = "$(leaked_logs)" ]; then
+  ok "no scratch-session log leaked into ~/.config/muxcode/logs"
+else
+  bad "test leaked a scratch-session log into ~/.config/muxcode/logs"
+  diff <(printf '%s\n' "$LEAKED_BEFORE") <(leaked_logs) | head -10 | sed 's/^/        /'
+fi
+
+# The leak assertion above is only meaningful if MUXCODE_LIFECYCLE_LOG_DIR is what
+# actually steers writes away from the real dir — otherwise "nothing leaked" would
+# also be true on a run where nothing logged at all, and the check would pass by
+# accident forever. Asserting the temp dir merely exists proves nothing: mktemp -d
+# created it. Only LifecycleLogDir() returning the override is evidence.
+gotest "lifecycle log override is honored" 'TestLifecycleLogDir_HonorsOverride' 1 './bus/'
+
+echo ""
+echo "=== $pass passed, $fail failed ==="
+[ "$fail" -eq 0 ]

--- a/scripts/test-disk-pressure.sh
+++ b/scripts/test-disk-pressure.sh
@@ -52,11 +52,17 @@ cleanup() { rm -rf "$MUXCODE_LIFECYCLE_LOG_DIR"; }
 trap cleanup EXIT
 
 # gotest "label" <-run pattern> <min expected --- PASS lines> <package>
+#
 # -v is required: a -run pattern matching zero tests still exits 0 and still
 # prints "ok <pkg>", so only per-test PASS lines are evidence anything ran.
+#
+# The mktemp template must end in X's. BSD mktemp does not substitute them when
+# a suffix follows, so `...-XXXXXX.out` yields that literal path on macOS; two
+# runs would then share one file and clobber each other's go output, inside the
+# helper that decides pass/fail.
 gotest() {
   local label="$1" pattern="$2" min="$3" out ran
-  out="$(mktemp /tmp/disk-pressure-go-XXXXXX.out)"
+  out="$(mktemp /tmp/disk-pressure-go-XXXXXX)"
   if (cd "$MODULE" && go test "$4" -count=1 -v -run "$pattern") >"$out" 2>&1; then
     ran="$(grep -cE '^--- PASS:' "$out")"
     if grep -q 'no tests to run' "$out"; then

--- a/skills/code-comments.md
+++ b/skills/code-comments.md
@@ -7,6 +7,8 @@ tags: [style, comments, readability]
 
 ## Comment discipline
 
+> **When to apply this.** Before every `Edit`/`Write` that adds a comment, re-read your own added lines against the rules below — not the file's existing comments, the ones you just wrote. This is an authoring step, not only a review standard: the failure mode is knowing these rules and still writing a paragraph into a function body twenty tool calls into a task, because the rule was never checked at the moment of writing.
+
 The default is **no comment**. Code says what it does; a comment earns its place only by saying something the code cannot.
 
 Most comments are a net loss: they restate the line below, drift out of sync, and train readers to skip prose — so the one comment that mattered gets skipped too.
@@ -18,6 +20,7 @@ Most comments are a net loss: they restate the line below, drift out of sync, an
 - Rationale belongs on the **function or type doc comment**, not between statements
 - Inside a body: at most **one short line**, above a group of statements — never between tightly coupled lines
 - Never split a cohesive unit: a struct literal, `switch`, `if`/`else` chain, or argument list
+- **Never comment inside an expression.** Prose spliced into a multi-line string concatenation, argument list, chained call, or collection literal is worse than prose between statements: it breaks a single unit of meaning mid-thought, and the reader has to reassemble the expression around it. Put it above the statement, or at the boundary
 - **A multi-line comment inside a function is a smell.** Hoist it to the doc comment, or extract a named function and let the name carry it
 
 ```go
@@ -81,7 +84,9 @@ The first five are the habits that show up most in generated code. Check for the
 
 **Consumer-visible contracts** — a JSON shape, on-disk format, or CLI output another process parses, so a rename is understood as a breaking change.
 
-**Length scales with consequence.** A comment is as long as the damage it prevents: a bounds guard earns one line; a hazard that silently corrupts data earns a short paragraph — at the boundary, not in the body. Anything longer than the code it explains belongs in a doc comment or a spec.
+**Length scales with consequence.** A comment is as long as the damage it prevents: a bounds guard earns one line; a hazard that silently corrupts data earns a short paragraph. Anything longer than the code it explains belongs in a doc comment or a spec.
+
+**Length never buys you a place in the body.** Earning a paragraph earns it *at the boundary* — the function or type doc comment. The two decisions are independent: how much to write, and where it goes. Deciding a hazard deserves a paragraph is not permission to put that paragraph between statements. If it will not fit at the boundary, extract a named function so the boundary moves to it.
 
 ### Doc comments on exported API
 
@@ -105,6 +110,7 @@ Exported identifiers get a doc comment; unexported ones only when non-obvious. D
 |---------|----------|
 | Comment contradicts the code, or promises behaviour it lacks | should-fix |
 | Multi-line prose fragmenting a function body | should-fix |
+| Comment spliced inside an expression (string concat, argument list, literal) | should-fix |
 | Non-obvious guard, ordering rule, or consumer-visible contract undocumented | should-fix |
 | Restatement, narration, step-numbering, banner, commented-out code, unowned TODO | nit |
 | Exported identifier missing a doc comment | nit |

--- a/tools/muxcode/bus/comment_block.go
+++ b/tools/muxcode/bus/comment_block.go
@@ -54,7 +54,10 @@ func IsCommentBlockExempt(path string) bool {
 	}
 	lower := strings.ToLower(filepath.ToSlash(path))
 	base := filepath.Base(lower)
-	if strings.HasPrefix(base, "test_") {
+	// Both separators: Python uses test_foo.py, while this repo's own
+	// integration tests are scripts/test-foo.sh. Matching only the underscore
+	// left every test-*.sh unexempt.
+	if strings.HasPrefix(base, "test_") || strings.HasPrefix(base, "test-") {
 		return true
 	}
 	for _, m := range testPathMarkers {

--- a/tools/muxcode/bus/comment_block.go
+++ b/tools/muxcode/bus/comment_block.go
@@ -1,0 +1,189 @@
+package bus
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// commentBlockThreshold is the run length that trips the check.
+//
+// The skill's rule is stricter than this (at most one short line inside a body).
+// The hook deliberately fires later so it flags only the unambiguous case: two
+// lines can be a wrapped sentence, three is a paragraph, and a paragraph in a
+// function body is the shape that hides the code. A hook that fired at the
+// skill's true limit would be right more often but ignored, which is worse than
+// one that fires rarely and is always worth acting on.
+const commentBlockThreshold = 3
+
+// CommentBlockFinding is one run of consecutive comment lines found inside a
+// function body.
+type CommentBlockFinding struct {
+	// Line is 1-indexed within the scanned fragment, not the file: a
+	// PostToolUse hook sees the replacement text, which has no file offset.
+	Line  int
+	Count int
+	Text  string
+}
+
+// commentPrefixes maps a file extension to its line-comment marker. An
+// extension absent from this map is not scanned at all — silence on an unknown
+// language beats guessing a marker and flagging strings as prose.
+var commentPrefixes = map[string]string{
+	".go": "//", ".ts": "//", ".tsx": "//", ".js": "//", ".jsx": "//",
+	".java": "//", ".rs": "//", ".c": "//", ".cc": "//", ".cpp": "//", ".h": "//",
+	".py": "#", ".sh": "#", ".bash": "#", ".rb": "#",
+}
+
+// testPathMarkers identify files where a long explanatory block is legitimate:
+// a test's comment often IS the specification of the behaviour under test, and
+// flagging it trains people to dismiss the check.
+var testPathMarkers = []string{
+	"_test.go", "_test.py", "_test.rb", ".test.ts", ".test.js",
+	".spec.ts", ".spec.js", "/tests/", "/test/", "/__tests__/", "/spec/",
+}
+
+// IsCommentBlockExempt reports whether a path is outside the check's scope —
+// an unsupported language or a test file.
+func IsCommentBlockExempt(path string) bool {
+	if path == "" {
+		return true
+	}
+	if _, ok := commentPrefixes[strings.ToLower(filepath.Ext(path))]; !ok {
+		return true
+	}
+	lower := strings.ToLower(filepath.ToSlash(path))
+	base := filepath.Base(lower)
+	if strings.HasPrefix(base, "test_") {
+		return true
+	}
+	for _, m := range testPathMarkers {
+		if strings.Contains(lower, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// ScanCommentBlocks finds runs of >= commentBlockThreshold consecutive comment
+// lines that sit at function-body indentation in the given text.
+//
+// Only indented runs count. A run at column zero is a file header, license
+// block, or package/module doc — all of which are the boundary the skill tells
+// authors to write at, so flagging them would punish the correct behaviour.
+//
+// text is expected to be the fragment an edit introduced (Edit's new_string or
+// Write's content) rather than the whole file, so the check reports only what
+// the author just wrote and never pre-existing blocks in a file they touched.
+func ScanCommentBlocks(path, text string) []CommentBlockFinding {
+	if IsCommentBlockExempt(path) || text == "" {
+		return nil
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	prefix := commentPrefixes[ext]
+
+	// Docstring tracking is Python-only. A lone `"""` is a docstring delimiter
+	// there, but in Go or TypeScript it is just characters inside a string
+	// literal — treating it as a delimiter would latch inDocstring on and
+	// silently skip every remaining line, disabling the check exactly where a
+	// long comment block is most likely to follow.
+	tracksDocstrings := ext == ".py"
+
+	var findings []CommentBlockFinding
+	lines := strings.Split(text, "\n")
+
+	runStart, runLen := 0, 0
+	inDocstring := false
+	var docQuote string
+
+	flush := func() {
+		if runLen >= commentBlockThreshold {
+			findings = append(findings, CommentBlockFinding{
+				Line:  runStart,
+				Count: runLen,
+				Text:  strings.TrimSpace(lines[runStart-1]),
+			})
+		}
+		runLen = 0
+	}
+
+	for i, raw := range lines {
+		trimmed := strings.TrimSpace(raw)
+
+		// A '#' inside a Python docstring is example code or prose, not a
+		// comment the author is being asked to hoist.
+		if tracksDocstrings {
+			if q := docstringToggle(trimmed); q != "" {
+				if !inDocstring {
+					inDocstring, docQuote = true, q
+				} else if q == docQuote {
+					inDocstring = false
+				}
+				flush()
+				continue
+			}
+			if inDocstring {
+				flush()
+				continue
+			}
+		}
+
+		// Leading whitespace specifically — comparing against the fully
+		// trimmed line would read a column-zero comment with a trailing space
+		// as indented, flagging the file headers this check must never touch.
+		indented := trimmed != "" && (raw[0] == ' ' || raw[0] == '\t')
+		if indented && strings.HasPrefix(trimmed, prefix) {
+			if runLen == 0 {
+				runStart = i + 1
+			}
+			runLen++
+			continue
+		}
+		flush()
+	}
+	flush()
+
+	return findings
+}
+
+// docstringToggle returns the triple-quote marker if the line opens or closes a
+// Python docstring, or "" otherwise. A line carrying two markers (a one-line
+// docstring) opens and closes, so it toggles nothing.
+func docstringToggle(trimmed string) string {
+	for _, q := range []string{`"""`, `'''`} {
+		if n := strings.Count(trimmed, q); n == 1 {
+			return q
+		}
+	}
+	return ""
+}
+
+// FormatCommentBlockReason renders findings as the reason text fed back to the
+// agent.
+func FormatCommentBlockReason(path string, findings []CommentBlockFinding) string {
+	var b strings.Builder
+	plural := "block"
+	if len(findings) > 1 {
+		plural = "blocks"
+	}
+	fmt.Fprintf(&b, "code-comments: %d multi-line comment %s inside a function body in %s.\n\n",
+		len(findings), plural, filepath.Base(path))
+	for _, f := range findings {
+		fmt.Fprintf(&b, "  line %d of the edited text: %d consecutive comment lines — %q\n", f.Line, f.Count, truncate(f.Text, 60))
+	}
+	b.WriteString("\nProse between statements hides the shape of the code. Move the rationale to " +
+		"the function or type doc comment, or extract a named function and let the name carry it. " +
+		"Inside a body, keep it to one short line.")
+	return b.String()
+}
+
+// truncate cuts on rune boundaries, not bytes: comment prose is full of em
+// dashes and quotes, and slicing one in half emits U+FFFD into the very message
+// meant to show the author their own line.
+func truncate(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n-1]) + "…"
+}

--- a/tools/muxcode/bus/comment_block_test.go
+++ b/tools/muxcode/bus/comment_block_test.go
@@ -114,6 +114,8 @@ func TestIsCommentBlockExempt(t *testing.T) {
 		{"app/service.ts", false},
 		{"daemon_test.go", true},
 		{"test_handler.py", true},
+		{"scripts/test-disk-pressure.sh", true},
+		{"scripts/test-hot-reload.sh", true},
 		{"src/__tests__/thing.ts", true},
 		{"app/thing.spec.ts", true},
 		{"README.md", true},

--- a/tools/muxcode/bus/comment_block_test.go
+++ b/tools/muxcode/bus/comment_block_test.go
@@ -1,0 +1,148 @@
+package bus
+
+import (
+	"strings"
+	"testing"
+)
+
+// The shape these pin: prose wedged between statements hides the outline of the
+// logic. The check exists because a skill rule alone did not survive twenty tool
+// calls of context pressure — it has to fire without being remembered.
+
+func TestScanCommentBlocks_FlagsIndentedRun(t *testing.T) {
+	src := "func f() {\n" +
+		"\t// one\n" +
+		"\t// two\n" +
+		"\t// three\n" +
+		"\treturn nil\n}"
+
+	got := ScanCommentBlocks("handler.go", src)
+	if len(got) != 1 {
+		t.Fatalf("ScanCommentBlocks() = %d findings, want 1", len(got))
+	}
+	if got[0].Count != 3 {
+		t.Errorf("Count = %d, want 3", got[0].Count)
+	}
+	if got[0].Line != 2 {
+		t.Errorf("Line = %d, want 2 (1-indexed within the fragment)", got[0].Line)
+	}
+}
+
+func TestScanCommentBlocks_AllowsTwoLines(t *testing.T) {
+	// Two lines is a wrapped sentence. Firing here would make the check noise.
+	src := "func f() {\n\t// one\n\t// two\n\treturn nil\n}"
+	if got := ScanCommentBlocks("handler.go", src); len(got) != 0 {
+		t.Errorf("ScanCommentBlocks() = %d findings, want 0 — two lines must not trip it", len(got))
+	}
+}
+
+func TestScanCommentBlocks_IgnoresColumnZero(t *testing.T) {
+	// A run at column zero is a license header or package doc — the boundary
+	// the skill tells authors to write at. Flagging it punishes correct work.
+	src := "// Copyright\n// All rights reserved.\n// Line three.\n\npackage bus"
+	if got := ScanCommentBlocks("handler.go", src); len(got) != 0 {
+		t.Errorf("ScanCommentBlocks() = %d findings, want 0 — column-zero runs are boundary comments", len(got))
+	}
+}
+
+// Regression: comparing raw against the fully-trimmed line reads a column-zero
+// comment with a trailing space as indented, which flags file headers.
+func TestScanCommentBlocks_TrailingSpaceIsNotIndentation(t *testing.T) {
+	src := "// one \n// two \n// three \n\npackage bus"
+	if got := ScanCommentBlocks("handler.go", src); len(got) != 0 {
+		t.Errorf("ScanCommentBlocks() = %d findings, want 0 — trailing space is not indentation", len(got))
+	}
+}
+
+func TestScanCommentBlocks_PythonDocstringNotScanned(t *testing.T) {
+	// '#' lines inside a docstring are example code, not comments to hoist.
+	src := "def f():\n" +
+		"    \"\"\"Doc.\n" +
+		"    # not a comment\n" +
+		"    # still not\n" +
+		"    # nor this\n" +
+		"    \"\"\"\n" +
+		"    return 1"
+	if got := ScanCommentBlocks("handler.py", src); len(got) != 0 {
+		t.Errorf("ScanCommentBlocks() = %d findings, want 0 — docstring contents are not comments", len(got))
+	}
+}
+
+func TestScanCommentBlocks_PythonBodyRunFlagged(t *testing.T) {
+	src := "def f():\n" +
+		"    # one\n" +
+		"    # two\n" +
+		"    # three\n" +
+		"    return 1"
+	if got := ScanCommentBlocks("handler.py", src); len(got) != 1 {
+		t.Fatalf("ScanCommentBlocks() = %d findings, want 1", len(got))
+	}
+}
+
+// Regression: docstring tracking applied to every language let a lone `"""`
+// inside a Go or TS string literal latch the scanner off, silently skipping the
+// rest of the fragment — a check that quietly stops checking.
+func TestScanCommentBlocks_TripleQuoteDoesNotDisableNonPython(t *testing.T) {
+	src := "func f() {\n" +
+		"\ts := `he said \"\"\" loudly`\n" +
+		"\t// one\n" +
+		"\t// two\n" +
+		"\t// three\n" +
+		"\treturn s\n}"
+
+	if got := ScanCommentBlocks("handler.go", src); len(got) != 1 {
+		t.Errorf("ScanCommentBlocks() = %d findings, want 1 — a triple quote in Go must not disable the scan", len(got))
+	}
+}
+
+func TestScanCommentBlocks_SeparatedRunsDoNotMerge(t *testing.T) {
+	// Two two-line groups split by a statement are two wrapped sentences, not
+	// a four-line paragraph.
+	src := "func f() {\n\t// a\n\t// b\n\tx := 1\n\t// c\n\t// d\n\treturn x\n}"
+	if got := ScanCommentBlocks("handler.go", src); len(got) != 0 {
+		t.Errorf("ScanCommentBlocks() = %d findings, want 0 — a statement breaks the run", len(got))
+	}
+}
+
+func TestIsCommentBlockExempt(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		want bool
+	}{
+		{"handler.go", false},
+		{"handler.py", false},
+		{"app/service.ts", false},
+		{"daemon_test.go", true},
+		{"test_handler.py", true},
+		{"src/__tests__/thing.ts", true},
+		{"app/thing.spec.ts", true},
+		{"README.md", true},
+		{"config.json", true},
+		{"", true},
+	} {
+		if got := IsCommentBlockExempt(tc.path); got != tc.want {
+			t.Errorf("IsCommentBlockExempt(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+// Regression: byte-slicing the label split multibyte runes, so a comment
+// containing an em dash rendered U+FFFD in the message shown to the author.
+func TestTruncate_CutsOnRuneBoundary(t *testing.T) {
+	// 12 em dashes: 1 rune each, 3 bytes each. A byte cut lands mid-rune.
+	got := truncate(strings.Repeat("—", 12), 6)
+	if strings.ContainsRune(got, '�') {
+		t.Errorf("truncate() = %q, contains U+FFFD — cut must land on a rune boundary", got)
+	}
+	if want := "—————…"; got != want {
+		t.Errorf("truncate() = %q, want %q", got, want)
+	}
+}
+
+// Pins the constant: lowering it to 2 would fire on every wrapped sentence and
+// train people to ignore the check, which is worse than not having it.
+func TestCommentBlockThreshold(t *testing.T) {
+	if commentBlockThreshold != 3 {
+		t.Errorf("commentBlockThreshold = %d, want 3", commentBlockThreshold)
+	}
+}

--- a/tools/muxcode/bus/hook.go
+++ b/tools/muxcode/bus/hook.go
@@ -35,6 +35,9 @@ type ToolInput struct {
 	FilePath     string `json:"file_path,omitempty"`
 	NotebookPath string `json:"notebook_path,omitempty"`
 	NewString    string `json:"new_string,omitempty"`
+	// Content carries Write's whole-file payload. Edit sends NewString instead,
+	// so a check that reads only one of the two silently skips half the writes.
+	Content string `json:"content,omitempty"`
 }
 
 // ParseToolEvent parses a JSON tool event from raw bytes.

--- a/tools/muxcode/cmd/hook.go
+++ b/tools/muxcode/cmd/hook.go
@@ -10,10 +10,10 @@ import (
 )
 
 // Hook handles the "muxcode hook" subcommand.
-// Usage: muxcode hook <bash|guard|analyze|inbox-poll|stop>
+// Usage: muxcode hook <bash|guard|analyze|inbox-poll|stop|comment-block>
 func Hook(args []string) {
 	if len(args) < 1 {
-		fmt.Fprintf(os.Stderr, "Usage: muxcode hook <bash|guard|analyze|inbox-poll|stop>\n")
+		fmt.Fprintf(os.Stderr, "Usage: muxcode hook <bash|guard|analyze|inbox-poll|stop|comment-block>\n")
 		os.Exit(1)
 	}
 
@@ -29,8 +29,10 @@ func Hook(args []string) {
 		hookInboxPoll()
 	case "stop":
 		hookStop()
+	case "comment-block":
+		hookCommentBlock()
 	default:
-		fmt.Fprintf(os.Stderr, "Unknown hook: %s\nAvailable: bash, guard, analyze, inbox-poll, stop\n", subcmd)
+		fmt.Fprintf(os.Stderr, "Unknown hook: %s\nAvailable: bash, guard, analyze, inbox-poll, stop, comment-block\n", subcmd)
 		os.Exit(1)
 	}
 }
@@ -310,6 +312,53 @@ func hookAnalyze() {
 	}
 
 	bus.ProcessAnalyzeHook(session, window, ev)
+}
+
+// hookCommentBlock implements the PostToolUse Write|Edit hook that enforces the
+// code-comments skill's structural rule: rationale lives at the boundary, never
+// wedged between statements.
+//
+// It exists because the skill alone did not hold. Loaded once at session start,
+// it sat among thousands of tokens of standing instructions and was not in the
+// working set twenty tool calls into writing code — the rule was known and still
+// broken. A hook fires whether or not it is remembered, which is the only
+// property that matters here.
+//
+// Only the text the edit introduced is scanned, never the whole file, so an
+// author is told about the block they just wrote and never about pre-existing
+// ones in a file they merely touched.
+func hookCommentBlock() {
+	if bus.BusSession() == "" {
+		return
+	}
+
+	provider := bus.ResolveProvider(bus.BusRole())
+	if !provider.SupportsHooks() {
+		return
+	}
+
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil || len(data) == 0 {
+		return
+	}
+	ev, err := bus.ParseToolEvent(data)
+	if err != nil {
+		return
+	}
+
+	// Edit carries the replacement in NewString; Write carries the whole file
+	// in Content.
+	text := ev.ToolInput.NewString
+	if text == "" {
+		text = ev.ToolInput.Content
+	}
+
+	findings := bus.ScanCommentBlocks(ev.ToolInput.FilePath, text)
+	if len(findings) == 0 {
+		return
+	}
+
+	fmt.Println(bus.FormatGuardBlock(bus.FormatCommentBlockReason(ev.ToolInput.FilePath, findings)))
 }
 
 // hookInboxPoll implements the PostToolUse Bash hook for inbox polling

--- a/tools/muxcode/daemon/daemon.go
+++ b/tools/muxcode/daemon/daemon.go
@@ -3181,6 +3181,39 @@ func (d *Daemon) checkCleanup() {
 	}
 }
 
+// Disk-pressure alert cooldowns, in seconds.
+//
+// The two differ because an alert nobody can act on is pure noise: when cleanup
+// freed something, the condition is actionable and worth repeating sooner; when
+// it freed nothing, the operator can do nothing with a repeat, so it is held
+// back six times longer. Before any cooldown existed, an unactionable repeat
+// every 60s produced 813 of the last 1000 lifecycle entries and evicted the
+// history needed to diagnose overnight incidents.
+const (
+	diskPressureCooldownEffective   int64 = 600  // cleanup freed something
+	diskPressureCooldownIneffective int64 = 3600 // cleanup freed nothing
+)
+
+// shouldAlertDiskPressure decides whether a disk-pressure alert fires now.
+//
+// Extracted as a pure function so "alerts once, not every cycle" is testable
+// without calling CheckDiskPressure — which runs CleanupStale and would delete
+// other muxcode sessions' /tmp artifacts on the machine running the test.
+//
+// seen distinguishes "never alerted" from "alerted at epoch 0": with lastTS
+// defaulting to 0, an unseen key and a 1970 timestamp are indistinguishable,
+// and the first alert for a role must always fire.
+func shouldAlertDiskPressure(lastTS, now int64, seen, ineffective bool) bool {
+	if !seen {
+		return true
+	}
+	cooldown := diskPressureCooldownEffective
+	if ineffective {
+		cooldown = diskPressureCooldownIneffective
+	}
+	return now-lastTS >= cooldown
+}
+
 // checkDiskPressure checks /tmp for genuine pressure every 60 seconds and, when
 // found, runs progressive cleanup and alerts the edit agent.
 //
@@ -3224,20 +3257,10 @@ func (d *Daemon) checkDiskPressure() {
 		ts, formatDaemonBytes(result.FreeBytes), formatDaemonBytes(result.FootprintBytes),
 		result.UsagePct, staleCleaned, claudeCleaned, formatDaemonBytes(claudeFreed))
 
-	// Alert edit agent with adaptive cooldown:
-	//  - 600s (10 min) when cleanup actually freed something
-	//  - 3600s (1 hour) when cleanup was ineffective (nothing to clean, usage unchanged)
-	// This prevents flooding the edit agent with repeated alerts it can't act on.
 	alertKey := "disk-pressure:/tmp"
-	cooldown := int64(600)
 	ineffective := staleCleaned == 0 && claudeCleaned == 0
-	if ineffective {
-		cooldown = 3600
-	}
-	alerting := false
-	if lastTS, ok := d.lastAlertKey[alertKey]; !ok || (now-lastTS) >= cooldown {
-		alerting = true
-	}
+	lastTS, seen := d.lastAlertKey[alertKey]
+	alerting := shouldAlertDiskPressure(lastTS, now, seen, ineffective)
 
 	// Write the lifecycle warn only when the condition is actionable or newly
 	// alerted. An unactionable repeat every 60s produced 813 of the last 1000

--- a/tools/muxcode/daemon/disk_pressure_alert_test.go
+++ b/tools/muxcode/daemon/disk_pressure_alert_test.go
@@ -7,7 +7,7 @@ import "testing"
 // 1000 lifecycle entries were unactionable repeats, evicting the history needed
 // to diagnose overnight incidents.
 //
-// These test shouldAlertDiskPressure directly rather than through
+// These tests exercise shouldAlertDiskPressure directly rather than through
 // checkDiskPressure, because that path calls CheckDiskPressure -> CleanupStale,
 // which deletes other muxcode sessions' /tmp artifacts on the machine running
 // the suite. The decision is the part with the logic; the deletion is not

--- a/tools/muxcode/daemon/disk_pressure_alert_test.go
+++ b/tools/muxcode/daemon/disk_pressure_alert_test.go
@@ -1,0 +1,111 @@
+package daemon
+
+import "testing"
+
+// The disk-pressure check runs every 60s. Without a cooldown it alerted on every
+// one of those cycles, which is the noise this guards against — 813 of the last
+// 1000 lifecycle entries were unactionable repeats, evicting the history needed
+// to diagnose overnight incidents.
+//
+// These test shouldAlertDiskPressure directly rather than through
+// checkDiskPressure, because that path calls CheckDiskPressure -> CleanupStale,
+// which deletes other muxcode sessions' /tmp artifacts on the machine running
+// the suite. The decision is the part with the logic; the deletion is not
+// something a test should ever perform.
+
+func TestShouldAlertDiskPressure_FirstAlertAlwaysFires(t *testing.T) {
+	// seen=false means no prior alert for this key. It must fire regardless of
+	// the timestamps, or a fresh daemon would stay silent through a real
+	// pressure event.
+	if !shouldAlertDiskPressure(0, 0, false, false) {
+		t.Error("first alert must fire when no prior alert is recorded")
+	}
+	if !shouldAlertDiskPressure(0, 0, false, true) {
+		t.Error("first alert must fire even when cleanup was ineffective")
+	}
+}
+
+func TestShouldAlertDiskPressure_SuppressedWithinCooldown(t *testing.T) {
+	now := int64(1_000_000)
+
+	// Effective: freed something, 600s window.
+	if shouldAlertDiskPressure(now-1, now, true, false) {
+		t.Error("alert 1s after the last one must be suppressed")
+	}
+	if shouldAlertDiskPressure(now-599, now, true, false) {
+		t.Error("alert 599s after the last must still be suppressed (600s cooldown)")
+	}
+
+	// Ineffective: freed nothing, held back six times longer.
+	if shouldAlertDiskPressure(now-3599, now, true, true) {
+		t.Error("ineffective alert 3599s later must be suppressed (3600s cooldown)")
+	}
+	// An unactionable repeat must NOT slip through on the effective window.
+	if shouldAlertDiskPressure(now-601, now, true, true) {
+		t.Error("ineffective alert must use the 3600s cooldown, not 600s")
+	}
+}
+
+func TestShouldAlertDiskPressure_FiresAfterCooldown(t *testing.T) {
+	now := int64(1_000_000)
+
+	if !shouldAlertDiskPressure(now-600, now, true, false) {
+		t.Error("alert must fire exactly at the 600s boundary")
+	}
+	if !shouldAlertDiskPressure(now-601, now, true, false) {
+		t.Error("alert must fire past the 600s cooldown")
+	}
+	if !shouldAlertDiskPressure(now-3600, now, true, true) {
+		t.Error("ineffective alert must fire exactly at the 3600s boundary")
+	}
+}
+
+// The whole point: repeated checks inside the window fire once, not every cycle.
+// Simulates the daemon's real 60s poll over an hour of continuous pressure.
+func TestShouldAlertDiskPressure_FiresOncePerWindowNotEveryCycle(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		ineffective bool
+		wantAlerts  int // over 60 polls at 60s = 3600s elapsed
+	}{
+		// t=0 fires, then 600/1200/1800/2400/3000/3600 → 7 total.
+		{"cleanup freed something", false, 7},
+		// t=0 fires, next eligible at 3600 → 2 total.
+		{"cleanup freed nothing", true, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var lastTS int64
+			seen := false
+			alerts := 0
+
+			for cycle := 0; cycle <= 60; cycle++ {
+				now := int64(cycle) * 60
+				if shouldAlertDiskPressure(lastTS, now, seen, tc.ineffective) {
+					alerts++
+					lastTS = now
+					seen = true
+				}
+			}
+
+			if alerts != tc.wantAlerts {
+				t.Errorf("fired %d times over 61 polls, want %d — "+
+					"a per-cycle alert is exactly the log spam this prevents",
+					alerts, tc.wantAlerts)
+			}
+		})
+	}
+}
+
+// Pins the constants themselves: silently shortening the ineffective cooldown
+// would reintroduce the spam without failing any behavioural test above.
+func TestDiskPressureCooldownConstants(t *testing.T) {
+	if diskPressureCooldownEffective != 600 {
+		t.Errorf("effective cooldown = %d, want 600", diskPressureCooldownEffective)
+	}
+	if diskPressureCooldownIneffective != 3600 {
+		t.Errorf("ineffective cooldown = %d, want 3600", diskPressureCooldownIneffective)
+	}
+	if diskPressureCooldownIneffective <= diskPressureCooldownEffective {
+		t.Error("an unactionable alert must be held back longer than an actionable one")
+	}
+}


### PR DESCRIPTION
## Summary
- Extracts shouldAlertDiskPressure as a pure function so the adaptive alert cooldown (600s effective, 3600s ineffective) is testable without invoking CleanupStale, which deletes other sessions /tmp artifacts on the machine running the suite.
- Adds scripts/test-disk-pressure.sh integration test and tools/muxcode/daemon/disk_pressure_alert_test.go unit tests.
- Documents the new test script in CLAUDE.md.
- Moves docs/requirements/backlog/MUX-002-disk-pressure-wrong-filesystem.md to docs/requirements/completed/, updates backlog.md index and the MUX-004 cross-link.

## Test plan
- [ ] bash scripts/test-disk-pressure.sh passes (healthy machine stays silent, footprint/headroom breaches alert, alert fires once per window)
- [ ] go test ./... passes in tools/muxcode