### PR TITLE
MUX-127: Confirm PR exists before review loop proceeds

### DIFF
--- a/tools/muxcode/bus/graph_exec.go
+++ b/tools/muxcode/bus/graph_exec.go
@@ -457,7 +457,7 @@ func dispatchNode(session string, run *GraphRun, g *Graph, n *Node, st *GraphNod
 		})
 
 	case NodeCondition:
-		ctx := &ChainContext{Session: session}
+		ctx := &ChainContext{Session: session, Output: predecessorOutput(session, run, g, n.ID)}
 		passed, _ := EvaluateConditions(n.Conditions, ctx)
 		outcome := OutcomeFailure
 		if passed {
@@ -534,6 +534,30 @@ func nodeTimeoutSecs(n *Node) int {
 // finishNode records a terminal transition with an outcome. The outcome
 // must never be empty — an empty outcome matches no edge in
 // routeFinishedNodes, which would stall the subtree.
+// predecessorOutput joins the harvested outputs of a node's direct
+// predecessors so a condition node can branch on what the prior step
+// actually reported (output_contains). Without it a condition sees an
+// empty context and a pipeline sails past a step that answered
+// "nothing happened" — live incident 2026-08-31: the commit agent
+// declined PR creation, pr-read reported no PR, and the run still
+// reached its close gate.
+func predecessorOutput(session string, run *GraphRun, g *Graph, nodeID string) string {
+	statuses, err := ReadAllNodeStatuses(session, run.ID)
+	if err != nil {
+		return ""
+	}
+	var parts []string
+	for _, e := range g.Edges {
+		if e.To != nodeID {
+			continue
+		}
+		if st, ok := statuses[e.From]; ok && st.Output != "" {
+			parts = append(parts, st.Output)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
 func finishNode(session string, run *GraphRun, n *Node, outcome, output string) {
 	terminal := GraphNodeDone
 	if outcome == OutcomeFailure {

--- a/tools/muxcode/bus/graph_exec_test.go
+++ b/tools/muxcode/bus/graph_exec_test.go
@@ -136,6 +136,78 @@ func TestExecLinearRun(t *testing.T) {
 	}
 }
 
+// conditionOutputGraph is a send → condition(output_contains PR-CONFIRMED)
+// fan: success routes to b, failure to fail-note.
+func conditionOutputGraph() *Graph {
+	return &Graph{
+		Name:  "t",
+		Start: "a",
+		Nodes: []Node{
+			{ID: "a", Type: NodeSend, Role: "build", Action: "build", Message: "go"},
+			{ID: "chk", Type: NodeCondition, Conditions: map[string]any{"output_contains": "PR-CONFIRMED"}},
+			{ID: "b", Type: NodeSend, Role: "test", Action: "test", Message: "go"},
+			{ID: "fail-note", Type: NodeSend, Role: "build", Action: "build", Message: "retry"},
+		},
+		Edges: []Edge{
+			{From: "a", To: "chk"},
+			{From: "chk", To: "b"},
+			{From: "chk", To: "fail-note", Outcome: OutcomeFailure},
+		},
+	}
+}
+
+// completeSendNodeWithPayload answers a running send node with a real
+// response message so the node's harvested Output carries the payload.
+func completeSendNodeWithPayload(t *testing.T, session, runID, nodeID, payload string) {
+	t.Helper()
+	resp := NewMessage("build", "edit", "response", "response", payload, "")
+	if err := Send(session, resp); err != nil {
+		t.Fatal(err)
+	}
+	st, err := ReadNodeStatus(session, runID, nodeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	CompleteTask(session, st.TaskID, resp.ID)
+	row := HookHistoryEntry{TS: time.Now().Unix() + 1, Command: "./fake.sh",
+		ExitCode: "0", Outcome: OutcomeSuccess}
+	if err := WriteHookHistory(HistoryPath(session, "build"), row, 100); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A condition node must see its predecessor's harvested output — the
+// live 2026-08-31 incident had a run sail past a declined PR creation
+// because conditions evaluated against an empty context.
+func TestExecConditionSeesPredecessorOutput(t *testing.T) {
+	run := createTestRun(t, conditionOutputGraph())
+	step(t, runTestSession, run.ID)
+	completeSendNodeWithPayload(t, runTestSession, run.ID, "a", "PR-CONFIRMED https://github.com/x/y/pull/1")
+	step(t, runTestSession, run.ID)
+	step(t, runTestSession, run.ID)
+
+	if s := nodeState(t, runTestSession, run.ID, "b"); s != GraphNodeRunning {
+		t.Fatalf("b state %q, want running — condition did not see predecessor output", s)
+	}
+}
+
+// Negative control: without the token the condition fails and routes the
+// failure edge — a condition that always passes cannot survive this.
+func TestExecConditionFailsWithoutToken(t *testing.T) {
+	run := createTestRun(t, conditionOutputGraph())
+	step(t, runTestSession, run.ID)
+	completeSendNodeWithPayload(t, runTestSession, run.ID, "a", "NO-PR-FOUND for this branch")
+	step(t, runTestSession, run.ID)
+	step(t, runTestSession, run.ID)
+
+	if s := nodeState(t, runTestSession, run.ID, "fail-note"); s != GraphNodeRunning {
+		t.Fatalf("fail-note state %q, want running — failure edge not routed", s)
+	}
+	if s := nodeState(t, runTestSession, run.ID, "b"); s == GraphNodeRunning {
+		t.Fatal("b dispatched despite missing confirmation token")
+	}
+}
+
 func TestExecFailureRoutesFailureEdge(t *testing.T) {
 	g := linearGraph()
 	g.Nodes = append(g.Nodes, Node{ID: "fix", Type: NodeSpawn, Role: "edit", Message: "fix it"})

--- a/tools/muxcode/bus/graph_templates.go
+++ b/tools/muxcode/bus/graph_templates.go
@@ -102,6 +102,8 @@ var builtinGraphJSON = map[string]string{
   "nodes": [
     {"id": "gate1", "type": "wait_human", "message": "Approve staging, commit, push, and PR creation"},
     {"id": "a", "type": "send", "role": "commit", "action": "commit", "message": "Stage all unstaged files, commit, push, and create a PR"},
+    {"id": "verify-pr", "type": "send", "role": "commit", "action": "pr-read", "message": "Confirm an open PR exists for the current branch. Your reply MUST contain the literal token PR-CONFIRMED followed by its URL if one exists, or the literal token NO-PR-FOUND if none does — no other phrasing for that verdict"},
+    {"id": "pr-check", "type": "condition", "conditions": {"output_contains": "PR-CONFIRMED"}},
     {"id": "b", "type": "send", "role": "commit", "action": "pr-read", "message": "Watch for PR comments and report the review decision and any comments"},
     {"id": "gate2", "type": "wait_human", "message": "Approve addressing the review feedback and replying to comments"},
     {"id": "c", "type": "send", "role": "edit", "action": "edit", "message": "Address the PR review comments"},
@@ -112,7 +114,10 @@ var builtinGraphJSON = map[string]string{
   ],
   "edges": [
     {"from": "gate1", "to": "a"},
-    {"from": "a", "to": "b"},
+    {"from": "a", "to": "verify-pr"},
+    {"from": "verify-pr", "to": "pr-check"},
+    {"from": "pr-check", "to": "b"},
+    {"from": "pr-check", "to": "a", "outcome": "failure", "max_iterations": 3},
     {"from": "b", "to": "gate2"},
     {"from": "gate2", "to": "c"},
     {"from": "c", "to": "d"},

--- a/tools/muxcode/bus/graph_test.go
+++ b/tools/muxcode/bus/graph_test.go
@@ -370,6 +370,42 @@ func TestReviewFailureRoutesToFix(t *testing.T) {
 	}
 }
 
+// The commit-pr-review-loop must CONFIRM the PR exists before watching
+// it: a live run (2026-08-31, is-advising-gateway) reached its close
+// gate with no PR because the commit node's decline derived
+// unknown→success. verify-pr demands a literal token, pr-check branches
+// on it, and the failure edge loops back to the commit node — capped.
+func TestCommitPrReviewLoopVerifiesPr(t *testing.T) {
+	g, err := ParseGraph([]byte(builtinGraphJSON["commit-pr-review-loop"]))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var check *Node
+	for i := range g.Nodes {
+		if g.Nodes[i].ID == "pr-check" {
+			check = &g.Nodes[i]
+		}
+	}
+	if check == nil || check.Type != NodeCondition {
+		t.Fatal("pr-check condition node missing")
+	}
+	if v, ok := check.Conditions["output_contains"]; !ok || v != "PR-CONFIRMED" {
+		t.Errorf("pr-check conditions = %v, want output_contains PR-CONFIRMED", check.Conditions)
+	}
+	var success, cappedRetry bool
+	for _, e := range g.Edges {
+		if e.From == "pr-check" && e.To == "b" && e.Outcome == "" {
+			success = true
+		}
+		if e.From == "pr-check" && e.To == "a" && e.Outcome == OutcomeFailure && e.MaxIterations > 0 {
+			cappedRetry = true
+		}
+	}
+	if !success || !cappedRetry {
+		t.Errorf("pr-check edges incomplete: success=%v cappedRetry=%v", success, cappedRetry)
+	}
+}
+
 func TestResolveGraphTemplateBuiltin(t *testing.T) {
 	g, source, err := ResolveGraphTemplate("build-test-review")
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds a PR-existence check to the `commit-pr-review-loop` graph template between the commit/push node (`a`) and the PR-watch node (`b`). Previously `b` ("Watch for PR comments") could run against a branch with no open PR, since nothing verified `a` actually resulted in one.

## Changes

- `graph_templates.go`: insert `verify-pr` (a `send` node asking the commit agent to confirm an open PR exists for the current branch and reply with a literal `PR-CONFIRMED <url>` or `NO-PR-FOUND` token) and `pr-check` (a `condition` node on `output_contains: "PR-CONFIRMED"`) between `a` and `b`. On failure, loops back to `a` (retry commit/push/PR-create) up to 3 times before falling through.
- `graph_exec.go`: wiring to pass the predecessor node's output into condition evaluation (`predecessorOutput`) so `pr-check` can inspect `verify-pr`'s reply text.
- Tests added in `graph_exec_test.go` and `graph_test.go` covering the new condition wiring and template shape.

## Test Plan

- [ ] `go test ./...` (bus package) — new tests in `graph_exec_test.go`/`graph_test.go`
- [ ] `muxcode graph validate commit-pr-review-loop` — confirm the updated template still validates (reachability, capped-cycle rule, join sanity)
