### PR TITLE
MUX-132 Make dispatch-path stale-approval purge fail closed

### DIFF
--- a/tools/muxcode/bus/graph_exec.go
+++ b/tools/muxcode/bus/graph_exec.go
@@ -430,6 +430,21 @@ func resolveCurrentPhaseText(session string) string {
 	return p.Title
 }
 
+// purgeStaleApproval removes a gate's approved marker left by a previous
+// pass (graph retry --from, or a loop edge re-arming the gate) so a fresh
+// pass demands a fresh approval — a surviving marker would let
+// harvestWaitingNode release the gate instantly, a retried run sailing
+// through its human gate with nobody approving (MUX-132). Fails closed
+// like RetryGraphRun's purge: on an unremovable marker the caller must
+// fail the node, never arm a gate the stale approval can release.
+func purgeStaleApproval(session, runID, nodeID string) error {
+	err := os.Remove(graphApprovalPath(session, runID, nodeID, "approved"))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
 // dispatchNode fires a ready node's work and moves it to running/waiting.
 //
 // A suppressed send means the identical request is already queued or in
@@ -528,23 +543,18 @@ func dispatchNode(session string, run *GraphRun, g *Graph, n *Node, st *GraphNod
 		finishCondition(session, run, n, outcome)
 
 	case NodeJoin:
-		// The barrier was satisfied when the node was armed; a join
-		// completes immediately.
+		// The barrier was satisfied at arming — a join completes immediately.
 		_ = TransitionGraphNode(session, run.ID, n.ID, GraphNodeRunning, nil)
 		finishNode(session, run, n, OutcomeSuccess, "")
 
 	case NodeWaitHuman:
 		prompt := interpolateGraphMessage(session, n.Message, run.Intent, "")
-		// A fresh pass through a gate requires a fresh approval: purge any
-		// approved marker left by a previous pass (graph retry --from, or a
-		// loop edge re-arming the gate). Without this, harvestWaitingNode
-		// sees the stale marker and releases the gate instantly — a retried
-		// run would sail through its human gate with nobody approving.
-		_ = os.Remove(graphApprovalPath(session, run.ID, n.ID, "approved"))
-		// The pending marker is informational (surfaced by graph status);
-		// the release signal is the approved marker plus the edit
-		// notification below, so a marker write failure is logged but
-		// does not block the gate.
+		if err := purgeStaleApproval(session, run.ID, n.ID); err != nil {
+			finishNode(session, run, n, OutcomeFailure,
+				fmt.Sprintf("cannot purge stale approval for gate %q: %v", n.ID, err))
+			return
+		}
+		// The pending marker is informational — a write failure logs, never blocks the gate.
 		if err := os.MkdirAll(graphApprovalsDir(session, run.ID), 0755); err != nil {
 			LogLifecycle(session, "warn", "daemon", "graph-gate-marker-error",
 				fmt.Sprintf("%s: %s: %v", run.ID, n.ID, err))
@@ -561,13 +571,10 @@ func dispatchNode(session string, run *GraphRun, g *Graph, n *Node, st *GraphNod
 				run.ID, n.ID, prompt, run.ID, n.ID), "")
 		_ = SendNoCC(session, gate)
 		_ = Notify(session, "edit")
-		// Gate surfacing is the control pane's job: it switches itself to
-		// Pending Gates on the next tick (MUX-108). The graph popups were
-		// removed with the pane's arrival — no modal fallback remains.
+		// Gate surfacing is the control pane's job (MUX-108) — no modal fallback remains.
 
 	case NodeWaitEvent:
-		// Parked here; harvestWaitingNode releases it when a bus message
-		// with the node's event action is observed.
+		// Parked — harvestWaitingNode releases it on the node's event action.
 		_ = TransitionGraphNode(session, run.ID, n.ID, GraphNodeWaiting, nil)
 	}
 }

--- a/tools/muxcode/bus/graph_exec_test.go
+++ b/tools/muxcode/bus/graph_exec_test.go
@@ -779,6 +779,72 @@ func TestExecRetryPurgeFailureFailsClosed(t *testing.T) {
 	}
 }
 
+// TestExecDispatchPurgeFailureFailsClosed pins the dispatch-time purge's
+// error contract (MUX-132 post-close finding): when a stale approved
+// marker cannot be removed as the gate arms, the node must FAIL — never
+// reach waiting, where harvestWaitingNode would release it on the
+// surviving marker and relaunder the approval through the dispatch door.
+func TestExecDispatchPurgeFailureFailsClosed(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root — directory permissions cannot block os.Remove")
+	}
+	g := &Graph{
+		Name:  "t",
+		Start: "a",
+		Nodes: []Node{
+			{ID: "a", Type: NodeSend, Role: "build", Action: "build", Message: "go"},
+			{ID: "gate", Type: NodeWaitHuman, Message: "approve"},
+			{ID: "c", Type: NodeSend, Role: "commit", Action: "commit", Message: "ship it"},
+		},
+		Edges: []Edge{{From: "a", To: "gate"}, {From: "gate", To: "c"}},
+	}
+	run := createTestRun(t, g)
+
+	step(t, runTestSession, run.ID)
+	completeSendNode(t, runTestSession, run.ID, "a", OutcomeSuccess)
+
+	// Plant a stale marker, then make it un-removable before the gate dispatches.
+	approvals := graphApprovalsDir(runTestSession, run.ID)
+	if err := os.MkdirAll(approvals, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(graphApprovalPath(runTestSession, run.ID, "gate", "approved"), []byte("{}"), 0644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	if err := os.Chmod(approvals, 0555); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(approvals, 0755) })
+
+	step(t, runTestSession, run.ID)
+	if s := nodeState(t, runTestSession, run.ID, "gate"); s != GraphNodeFailed {
+		t.Fatalf("gate state %q after failed purge, want failed — never waiting on a stale approval", s)
+	}
+	if s := nodeState(t, runTestSession, run.ID, "c"); s != GraphNodePending {
+		t.Fatalf("c state %q, want pending — the gated node must not fire", s)
+	}
+	step(t, runTestSession, run.ID)
+	got, _ := ReadGraphRun(runTestSession, run.ID)
+	if got.State != GraphRunFailed {
+		t.Fatalf("run state %q, want failed — the refused purge must surface loudly", got.State)
+	}
+
+	// Positive control: restored permission → retry re-arms, dispatch purges and waits.
+	if err := os.Chmod(approvals, 0755); err != nil {
+		t.Fatalf("restore chmod: %v", err)
+	}
+	if _, err := RetryGraphRun(runTestSession, run.ID, "gate"); err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	step(t, runTestSession, run.ID)
+	if s := nodeState(t, runTestSession, run.ID, "gate"); s != GraphNodeWaiting {
+		t.Fatalf("gate state %q after restore, want waiting — positive control", s)
+	}
+	if _, err := os.Stat(graphApprovalPath(runTestSession, run.ID, "gate", "approved")); !os.IsNotExist(err) {
+		t.Fatalf("approved marker survived dispatch (err=%v) — the purge must remove it", err)
+	}
+}
+
 // TestExecRetryBelowParallelGateCutRearmsAll pins the cut form of the
 // re-arm (review finding, 2026-08-31): with the target fed by two
 // parallel branches each behind its own satisfied gate, NO single gate


### PR DESCRIPTION
## Summary
- The retry-path stale-approval purge (RetryGraphRun) already failed closed on an unremovable marker, but the dispatch-path purge in dispatchNode used a fire-and-forget os.Remove that silently ignored errors, leaving an asymmetry where a gate could still arm with a surviving stale approval marker.
- Extracted purgeStaleApproval and now check its error in dispatchNode: on failure the wait_human node fails loudly instead of reaching waiting, closing the last gap noted in the MUX-132 spec Post-close hardening section.

## Changes
- tools/muxcode/bus/graph_exec.go: new purgeStaleApproval helper; dispatchNode now fails the node on a purge error instead of ignoring it.
- tools/muxcode/bus/graph_exec_test.go: TestExecDispatchPurgeFailureFailsClosed pins the fail-closed contract (blocked marker leads to node and run fail, gated downstream node never fires) with a positive control (permission restored, retry re-arms and purges correctly).

## Test plan
- [ ] CI test check passes